### PR TITLE
call defineDriver before trying to use cordovaSQLiteDriver

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -72,13 +72,14 @@ export class Storage {
       name        : '_ionicstorage',
       storeName   : '_ionickv'
     });
-
-    this._db.setDriver([
+    this._db.defineDriver(CordovaSQLiteDriver).then(() => this._db.setDriver([
       CordovaSQLiteDriver._driver,
       this._db.INDEXEDDB,
       this._db.WEBSQL,
       this._db.LOCALSTORAGE
-    ])
+    ])).then(() => {
+      console.info('Ionic Storage driver:', this._db.driver());
+    });
   }
 
   /**


### PR DESCRIPTION
The `cordovaSQLiteDriver` will never be used unless `defineDriver` is called first as mentioned in the [localForage-cordovaSQLiteDriver readme](https://github.com/thgreasi/localForage-cordovaSQLiteDriver#setup-your-project).  Fixes #14.