### PR TITLE
Ensure the LocalForage instance is properly initialised

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -69,22 +69,23 @@ import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
  */
 @Injectable()
 export class Storage {
-  _db: any;
+  private _db: Promise<LocalForage>;
 
   constructor() {
-    this._db = LocalForage;
-
-    this._db.config({
-      name        : '_ionicstorage',
-      storeName   : '_ionickv'
-    });
-    this._db.defineDriver(CordovaSQLiteDriver).then(() => this._db.setDriver([
-      CordovaSQLiteDriver._driver,
-      this._db.INDEXEDDB,
-      this._db.WEBSQL,
-      this._db.LOCALSTORAGE
-    ])).then(() => {
-      console.info('Ionic Storage driver:', this._db.driver());
+    this._db = new Promise((resolve, reject) => {
+      LocalForage.config({
+        name        : '_ionicstorage',
+        storeName   : '_ionickv'
+      });
+      LocalForage.defineDriver(CordovaSQLiteDriver).then(() => LocalForage.setDriver([
+        CordovaSQLiteDriver._driver,
+        LocalForage.INDEXEDDB,
+        LocalForage.WEBSQL,
+        LocalForage.LOCALSTORAGE
+      ])).then(() => {
+        console.info('Ionic Storage driver:', LocalForage.driver());
+        resolve(LocalForage);
+      }).catch(error => reject(error));
     });
   }
 
@@ -93,7 +94,7 @@ export class Storage {
    * @return Promise that resolves with the value
    */
   get(key: string): Promise<any> {
-    return this._db.getItem(key);
+    return this._db.then(db => db.getItem(key));
   }
 
   /**
@@ -103,7 +104,7 @@ export class Storage {
    * @return Promise that resolves when the value is set
    */
   set(key: string, value: any) {
-    return this._db.setItem(key, value);
+    return this._db.then(db => db.setItem(key, value));
   }
 
   /**
@@ -112,7 +113,7 @@ export class Storage {
    * @return Promise that resolves when the value is removed
    */
   remove(key: string) {
-    return this._db.removeItem(key);
+    return this._db.then(db => db.removeItem(key));
   }
 
   /**
@@ -120,21 +121,21 @@ export class Storage {
    * @return Promise that resolves when the kv store is cleared
    */
   clear() {
-    return this._db.clear();
+    return this._db.then(db => db.clear());
   }
 
   /**
    * @return the number of keys stored.
    */
   length() {
-    return this._db.length();
+    return this._db.then(db => db.length());
   }
 
   /**
    * @return the keys in the store.
    */
   keys() {
-    return this._db.keys();
+    return this._db.then(db => db.keys());
   }
 
   /**
@@ -142,7 +143,7 @@ export class Storage {
    * @param iteratorCallback a callback of the form (value, key, iterationNumber)
    */
   forEach(iteratorCallback: (value: any, key: string, iterationNumber: Number) => any) {
-    return this._db.iterate(iteratorCallback);
+    return this._db.then(db => db.iterate(iteratorCallback));
   }
 
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -85,7 +85,7 @@ export class Storage {
         LocalForage.WEBSQL,
         LocalForage.LOCALSTORAGE
       ])).then(() => {
-        console.info('Ionic Storage driver:', LocalForage.driver());
+        console.info('Ionic Storage driver:', db.driver());
         resolve(db);
       }).catch(reason => reject(reason));
     });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -69,23 +69,25 @@ import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
  */
 @Injectable()
 export class Storage {
-  private _db: Promise<LocalForage>;
+  private _dbPromise: Promise<LocalForage>;
 
   constructor() {
-    this._db = new Promise((resolve, reject) => {
-      LocalForage.config({
-        name        : '_ionicstorage',
-        storeName   : '_ionickv'
-      });
-      LocalForage.defineDriver(CordovaSQLiteDriver).then(() => LocalForage.setDriver([
+    this._dbPromise = new Promise((resolve, reject) => {
+      let db: LocalForage;
+      LocalForage.defineDriver(CordovaSQLiteDriver).then(() => {
+        db = LocalForage.createInstance({
+          name        : '_ionicstorage',
+          storeName   : '_ionickv'
+        })
+      }).then(() => db.setDriver([
         CordovaSQLiteDriver._driver,
         LocalForage.INDEXEDDB,
         LocalForage.WEBSQL,
         LocalForage.LOCALSTORAGE
       ])).then(() => {
         console.info('Ionic Storage driver:', LocalForage.driver());
-        resolve(LocalForage);
-      }).catch(error => reject(error));
+        resolve(db);
+      }).catch(reason => reject(reason));
     });
   }
 
@@ -94,7 +96,7 @@ export class Storage {
    * @return Promise that resolves with the value
    */
   get(key: string): Promise<any> {
-    return this._db.then(db => db.getItem(key));
+    return this._dbPromise.then(db => db.getItem(key));
   }
 
   /**
@@ -104,7 +106,7 @@ export class Storage {
    * @return Promise that resolves when the value is set
    */
   set(key: string, value: any) {
-    return this._db.then(db => db.setItem(key, value));
+    return this._dbPromise.then(db => db.setItem(key, value));
   }
 
   /**
@@ -113,7 +115,7 @@ export class Storage {
    * @return Promise that resolves when the value is removed
    */
   remove(key: string) {
-    return this._db.then(db => db.removeItem(key));
+    return this._dbPromise.then(db => db.removeItem(key));
   }
 
   /**
@@ -121,21 +123,21 @@ export class Storage {
    * @return Promise that resolves when the kv store is cleared
    */
   clear() {
-    return this._db.then(db => db.clear());
+    return this._dbPromise.then(db => db.clear());
   }
 
   /**
    * @return the number of keys stored.
    */
   length() {
-    return this._db.then(db => db.length());
+    return this._dbPromise.then(db => db.length());
   }
 
   /**
    * @return the keys in the store.
    */
   keys() {
-    return this._db.then(db => db.keys());
+    return this._dbPromise.then(db => db.keys());
   }
 
   /**
@@ -143,7 +145,7 @@ export class Storage {
    * @param iteratorCallback a callback of the form (value, key, iterationNumber)
    */
   forEach(iteratorCallback: (value: any, key: string, iterationNumber: Number) => any) {
-    return this._db.then(db => db.iterate(iteratorCallback));
+    return this._dbPromise.then(db => db.iterate(iteratorCallback));
   }
 
 }


### PR DESCRIPTION
There's currently a race condition when Storage / LocalForage is initialised.

LocalForage calls [setDriver](https://github.com/localForage/localForage/blob/1.4.3/src/localforage.js#L119) in its constructor, so it will initially configure itself to use one of the built-in drivers before we call `defineDriver(CordovaSQLiteDriver)`. There's no way to register a custom driver beforehand.

As a result the first call to `storage.get('k')` can return `null` because it's reading from IndexedDB, even though a few milliseconds later it might be reconfigured to use SQLite and the same call will return some results.

LocalForage provides a [ready](https://github.com/localForage/localForage/blob/1.4.3/src/localforage.js#L250) method but again it only ensures that `setDriver` has finished, it doesn't help when using `defineDriver`.

So this patch keeps a reference to a promise to ensure the LocalForage instance has been fully initialised with CordovaSQLiteDriver, and uses it in all the API methods.

It also creates a separate LocalForage instance for Ionic Storage, just in case somebody is using the default LocalForage global instance already for something else.

Should fix #19 and #20.
