### PR TITLE
fix(storage): should take the engine param

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -150,7 +150,7 @@ export class Storage {
    * @param engine engine allows you to specify a specific storage engine to use.
    */
   setDriver(engine: string) {
-    this._db.setDriver(this._db.engine);
+    this._db.setDriver(engine);
   }
 
 }


### PR DESCRIPTION
In its current iteration `setDriver` will not actually set the storage engine to the one passed as the engine param. This fixes that.