### PR TITLE
chore(package.json): limit localforage version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@angular/core": "^2.0.0",
     "@types/localforage": "0.0.30",
-    "localforage": "^1.4.2",
-    "localforage-cordovasqlitedriver": "^1.5.0",
+    "localforage": "~1.4.2",
+    "localforage-cordovasqlitedriver": "~1.5.0",
     "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #28.
As per #28 (opened @ 23 Oct), at localforage we are planning to release v1.5 that will embed the respective typings as part of the npm package.
This is hopefully going to happen before Christmas, so I guess a new ionic-storage bugfix release should be released with this change.
**Otherwise the `@types/localforage` could conflict with the embedded localforage typings.**
I will open a new PR for the next localforage release as soon as it gets released