### PR TITLE
Update for Angular 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "typings": "es2015/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
-    "build-cjs": "tsc -p .",
-    "build-es2015": "tsc -p ./tsconfig-es2015.json",
+    "clean-generated": "rm -rf src/*.ngfactory.ts && rm -rf src/*.ngsummary.json",
+    "build-cjs": "ngc -p .",
+    "build-es2015": "ngc -p ./tsconfig-es2015.json",
     "preparePackage": "node ./scripts/copy-package",
-    "build": "npm run clean && npm run build-cjs && npm run build-es2015 && npm run preparePackage",
+    "build": "npm run clean && npm run build-cjs && npm run build-es2015 && npm run preparePackage && npm run clean-generated",
     "publishPackage": "npm run build && cd dist && npm publish"
   },
   "repository": {
@@ -36,7 +37,9 @@
     "localforage-cordovasqlitedriver": "~1.5.0"
   },
   "devDependencies": {
-    "@angular/core": "2.2.1",
+    "@angular/core": "2.4.5",
+    "@angular/compiler": "2.4.5",
+    "@angular/compiler-cli": "2.4.5",
     "@types/node": "^6.0.41",
     "canonical-path": "0.0.2",
     "cpr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/storage",
-  "version": "1.1.9",
+  "version": "2.0.0-0",
   "description": "Ionic Storage utility",
   "main": "es2015/index.js",
   "module": "es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "localforage-cordovasqlitedriver": "~1.5.0"
   },
   "devDependencies": {
-    "@angular/core": "2.4.5",
-    "@angular/compiler": "2.4.5",
-    "@angular/compiler-cli": "2.4.5",
+    "@angular/core": "2.4.8",
+    "@angular/compiler": "2.4.8",
+    "@angular/compiler-cli": "2.4.8",
     "@types/node": "^6.0.41",
     "canonical-path": "0.0.2",
     "cpr": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,19 @@
-import { Storage, StorageConfig } from './storage';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 
-export { Storage, StorageConfig };
+import { getDefaultConfig, provideStorage, Storage, StorageConfig, StorageConfigToken } from './storage';
+
+export { Storage, StorageConfig, StorageConfigToken };
+
+@NgModule({
+})
+export class IonicStorageModule {
+  static forRoot(storageConfig: StorageConfig = null): ModuleWithProviders {
+    return {
+      ngModule: IonicStorageModule,
+      providers: [
+        { provide: StorageConfigToken, useValue: storageConfig },
+        { provide: Storage, useFactory: provideStorage, deps: [StorageConfigToken]},
+      ]
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { Storage } from './storage';
+import { Storage, StorageConfig } from './storage';
 
-export { Storage };
+export { Storage, StorageConfig };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@angular/core';
+import { Injectable, OpaqueToken, Optional } from '@angular/core';
 
 import LocalForage from 'localforage';
 
@@ -112,7 +112,7 @@ export class Storage {
    * Possible driver options are: ['sqlite', 'indexeddb', 'websql', 'localstorage'] and the
    * default is that exact ordering.
    */
-  constructor(@Optional() config?: StorageConfig) {
+  constructor(@Optional() config?: any) {
     this._dbPromise = new Promise((resolve, reject) => {
       let db: LocalForage;
 
@@ -235,3 +235,10 @@ export interface StorageConfig {
     storeName?: string;
     driverOrder?: string[];
 };
+
+export function provideStorage(storageConfig?: StorageConfig) {
+  const config = !!storageConfig ? storageConfig : getDefaultConfig();
+  return new Storage(config);
+}
+
+export const StorageConfigToken = new OpaqueToken('STORAGE_CONFIG_TOKEN');

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 
 import LocalForage from 'localforage';
 
@@ -79,12 +79,13 @@ import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
  * The Storage engine can be configured both with specific storage engine priorities, or custom configuration
  * options to pass to localForage. See the localForage config docs for possible options: https://github.com/localForage/localForage#configuration
  *
+ * Note: Any custom configurations will be merged with the default configuration
  *
  * ```typescript
  * import { Storage } from '@ionic/storage';
  *
  * export function provideStorage() {
- *   return new Storage(['sqlite', 'websql', 'indexeddb'], { name: '__mydb' });
+ *   return new Storage({ name: '__mydb' });
  * }
  *
  * @NgModule({
@@ -111,26 +112,17 @@ export class Storage {
    * Possible driver options are: ['sqlite', 'indexeddb', 'websql', 'localstorage'] and the
    * default is that exact ordering.
    */
-  constructor(driverOrder: [string] = ['sqlite', 'indexeddb', 'websql', 'localstorage'], config?: any) {
+  constructor(@Optional() config?: StorageConfig) {
     this._dbPromise = new Promise((resolve, reject) => {
       let db: LocalForage;
 
-      let dbConfig = {
-        name        : '_ionicstorage',
-        storeName   : '_ionickv'
-      };
-
-      // Merge any custom config options they have
-      if(config) {
-        for(let k in config) {
-          dbConfig[k] = config[k];
-        }
-      }
+      const defaultConfig = getDefaultConfig();
+      const actualConfig = Object.assign(defaultConfig, config || {});
 
       LocalForage.defineDriver(CordovaSQLiteDriver).then(() => {
-        db = LocalForage.createInstance(dbConfig);
+        db = LocalForage.createInstance(actualConfig);
       })
-      .then(() => db.setDriver(this._getDriverOrder(driverOrder)))
+      .then(() => db.setDriver(this._getDriverOrder(actualConfig.driverOrder)))
       .then(() => {
         this._driver = db.driver();
         resolve(db);
@@ -229,3 +221,17 @@ export class Storage {
     return this._dbPromise.then(db => db.iterate(iteratorCallback));
   }
 }
+
+export function getDefaultConfig() {
+  return {
+    name        : '_ionicstorage',
+    storeName   : '_ionickv',
+    driverOrder: ['sqlite', 'indexeddb', 'websql', 'localstorage']
+  };
+}
+
+export interface StorageConfig {
+    name?: string;
+    storeName?: string;
+    driverOrder?: string[];
+};


### PR DESCRIPTION
This updates Ionic-Storage to work with Angular 2.4.x. Adds an NgModule instead of storage being a pure provider